### PR TITLE
Do not randomize source ports for natOutgoing

### DIFF
--- a/felix/iptables/actions.go
+++ b/felix/iptables/actions.go
@@ -153,9 +153,6 @@ type SNATAction struct {
 
 func (g SNATAction) ToFragment(features *environment.Features) string {
 	fullyRand := ""
-	if features.SNATFullyRandom {
-		fullyRand = " --random-fully"
-	}
 	return fmt.Sprintf("--jump SNAT --to-source %s%s", g.ToAddr, fullyRand)
 }
 
@@ -170,9 +167,6 @@ type MasqAction struct {
 
 func (g MasqAction) ToFragment(features *environment.Features) string {
 	fullyRand := ""
-	if features.MASQFullyRandom {
-		fullyRand = " --random-fully"
-	}
 	if g.ToPorts != "" {
 		return fmt.Sprintf("--jump MASQUERADE --to-ports %s"+fullyRand, g.ToPorts)
 	}


### PR DESCRIPTION
I think this breaks NAT Traversal (EIF). Particularly Tailscale. Disabling it seems to have downsides:
https://github.com/cilium/cilium/issues/13037, so will roll it out as limited test to begin with, and hopefully Cilium has a better solution.